### PR TITLE
#28: fixed jackson versioning

### DIFF
--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -178,22 +178,6 @@
         <artifactId>json</artifactId>
         <version>20180130</version>
       </dependency>
-      <!-- Jackson for JSON mapping -->
-      <dependency>
-        <groupId>com.fasterxml.jackson.jaxrs</groupId>
-        <artifactId>jackson-jaxrs-json-provider</artifactId>
-        <version>2.4.2</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>2.3.3</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>2.3.3</version>
-      </dependency>
       <!-- Dozer for bean-mapping/conversion (Alternative to Orika) -->
       <dependency>
         <groupId>net.sf.dozer</groupId>


### PR DESCRIPTION
simple fix to upgrade to `2.9.6` (that comes from spring BOM).