### PR TITLE
Fix spring dependencies in api (issue #37)

### DIFF
--- a/templates/server/src/main/resources/archetype-resources/api/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/api/pom.xml
@@ -14,6 +14,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-commons</artifactId>
+      <version>2.1.2.RELEASE</version>
+    </dependency>
+    <dependency>
       <groupId>com.devonfw.java.modules</groupId>
       <artifactId>devon4j-rest</artifactId>
     </dependency>


### PR DESCRIPTION
Adresses issue #37.
Changed the pom file in: https://github.com/devonfw/devon4j/blob/develop/templates/server/src/main/resources/archetype-resources/api/pom.xml#L15

Adding the dependency:
<dependency>
    <groupId>org.springframework.data</groupId>
    <artifactId>spring-data-commons</artifactId>
    <version>2.1.2.RELEASE</version>
</dependency>