### PR TITLE
moved RevisionedPersistenceEntity to devon4j-basic

### DIFF
--- a/modules/basic/src/main/java/com/devonfw/module/basic/common/api/entity/RevisionedPersistenceEntity.java
+++ b/modules/basic/src/main/java/com/devonfw/module/basic/common/api/entity/RevisionedPersistenceEntity.java
@@ -1,9 +1,6 @@
 /* Copyright (c) The m-m-m Team, Licensed under the Apache License, Version 2.0
  * http://www.apache.org/licenses/LICENSE-2.0 */
-package com.devonfw.module.jpa.dataaccess.api;
-
-import com.devonfw.module.basic.common.api.entity.PersistenceEntity;
-import com.devonfw.module.basic.common.api.entity.RevisionedEntity;
+package com.devonfw.module.basic.common.api.entity;
 
 /**
  * This is the interface for a {@link RevisionedEntity revisioned} {@link PersistenceEntity persistence entity}.

--- a/modules/jpa-dao/src/test/java/com/devonfw/example/general/dataaccess/api/TestApplicationPersistenceEntity.java
+++ b/modules/jpa-dao/src/test/java/com/devonfw/example/general/dataaccess/api/TestApplicationPersistenceEntity.java
@@ -8,7 +8,7 @@ import javax.persistence.Transient;
 import javax.persistence.Version;
 
 import com.devonfw.example.general.common.api.TestApplicationEntity;
-import com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity;
+import com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity;
 
 /**
  * Abstract Entity for all Entities with an id and a version field.

--- a/modules/jpa-dao/src/test/java/com/devonfw/module/jpa/dataaccess/base/AbstractPersistenceEntity.java
+++ b/modules/jpa-dao/src/test/java/com/devonfw/module/jpa/dataaccess/base/AbstractPersistenceEntity.java
@@ -7,7 +7,7 @@ import javax.persistence.MappedSuperclass;
 import javax.persistence.Transient;
 import javax.persistence.Version;
 
-import com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity;
+import com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity;
 
 /**
  * Abstract base implementation of {@link RevisionedPersistenceEntity}.

--- a/modules/jpa-envers/src/main/java/com/devonfw/module/jpa/dataaccess/api/GenericRevisionedDao.java
+++ b/modules/jpa-envers/src/main/java/com/devonfw/module/jpa/dataaccess/api/GenericRevisionedDao.java
@@ -7,6 +7,7 @@ import java.util.List;
 import javax.persistence.PersistenceException;
 
 import com.devonfw.module.basic.common.api.entity.RevisionedEntity;
+import com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity;
 
 /**
  * This is the interface for a {@link GenericDao} with the ability of revision-control. It organizes a revision-history

--- a/modules/jpa-envers/src/main/java/com/devonfw/module/jpa/dataaccess/api/RevisionedDao.java
+++ b/modules/jpa-envers/src/main/java/com/devonfw/module/jpa/dataaccess/api/RevisionedDao.java
@@ -1,6 +1,6 @@
 package com.devonfw.module.jpa.dataaccess.api;
 
-import com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity;
+import com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity;
 
 /**
  * This is a simplified variant of {@link GenericRevisionedDao} for the suggested and common case that you have a

--- a/modules/jpa-envers/src/main/java/com/devonfw/module/jpa/dataaccess/api/RevisionedMasterDataDao.java
+++ b/modules/jpa-envers/src/main/java/com/devonfw/module/jpa/dataaccess/api/RevisionedMasterDataDao.java
@@ -3,6 +3,7 @@ package com.devonfw.module.jpa.dataaccess.api;
 import java.util.List;
 
 import com.devonfw.module.basic.common.api.entity.PersistenceEntity;
+import com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity;
 
 /**
  * This is the interface for a {@link Dao} responsible for a {@link RevisionedPersistenceEntity} that represents

--- a/modules/jpa-envers/src/main/java/com/devonfw/module/jpa/dataaccess/base/AbstractGenericRevisionedDao.java
+++ b/modules/jpa-envers/src/main/java/com/devonfw/module/jpa/dataaccess/base/AbstractGenericRevisionedDao.java
@@ -8,9 +8,9 @@ import java.util.List;
 import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.AuditReaderFactory;
 
+import com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity;
 import com.devonfw.module.jpa.dataaccess.api.GenericRevisionedDao;
 import com.devonfw.module.jpa.dataaccess.api.RevisionMetadata;
-import com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity;
 import com.devonfw.module.jpa.dataaccess.impl.LazyRevisionMetadata;
 
 /**

--- a/modules/jpa-envers/src/main/java/com/devonfw/module/jpa/dataaccess/base/AbstractRevisionedDao.java
+++ b/modules/jpa-envers/src/main/java/com/devonfw/module/jpa/dataaccess/base/AbstractRevisionedDao.java
@@ -1,7 +1,7 @@
 package com.devonfw.module.jpa.dataaccess.base;
 
+import com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity;
 import com.devonfw.module.jpa.dataaccess.api.RevisionedDao;
-import com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity;
 
 /**
  * Abstract base implementation of {@link RevisionedDao} interface.

--- a/modules/jpa-spring-data/src/main/java/com/devonfw/module/jpa/dataaccess/api/data/GenericRevisionedRepository.java
+++ b/modules/jpa-spring-data/src/main/java/com/devonfw/module/jpa/dataaccess/api/data/GenericRevisionedRepository.java
@@ -9,28 +9,28 @@ import com.devonfw.module.jpa.dataaccess.api.RevisionMetadata;
  * {@link GenericRepository} with additional support for {@link org.hibernate.envers.Audited}
  *
  * @param <E> generic type of the managed {@link #getEntityClass() entity}. Typically implementing
- *        {@link com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity}.
- * @param <ID> generic type of the {@link com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity#getId()
+ *        {@link com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity}.
+ * @param <ID> generic type of the {@link com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity#getId()
  *        primary key} of the entity.
  * @since 3.0.0
  */
 public interface GenericRevisionedRepository<E, ID extends Serializable> extends GenericRepository<E, ID> {
 
   /**
-   * @param id the {@link com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity#getId() primary key}.
+   * @param id the {@link com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity#getId() primary key}.
    * @param revision the {@link RevisionMetadata#getRevision() revision} of the requested entity.
    * @return the entity with the given {@code id} and {@code revision}.
    * @see #find(Serializable)
    * @see #getRevisionHistoryMetadata(Serializable, boolean)
    * @see RevisionMetadata#getRevision()
-   * @see com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity#getRevision()
+   * @see com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity#getRevision()
    */
   E find(ID id, Number revision);
 
   /**
-   * @param id the {@link com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity#getId() primary key}.
+   * @param id the {@link com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity#getId() primary key}.
    * @return the {@link List} of {@link RevisionMetadata} for the historic
-   *         {@link com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity#getRevision() revisions} of the
+   *         {@link com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity#getRevision() revisions} of the
    *         entity with the given {@code id}. In case no such history exists, an {@link List#isEmpty() empty}
    *         {@link List} is returned.
    */
@@ -40,19 +40,19 @@ public interface GenericRevisionedRepository<E, ID extends Serializable> extends
   }
 
   /**
-   * @param id the {@link com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity#getId() primary key}.
+   * @param id the {@link com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity#getId() primary key}.
    * @param lazy - {@code true} to load the {@link RevisionMetadata} lazily, {@code false} otherwise (eager loading).
    * @return the {@link List} of {@link RevisionMetadata} for the historic
-   *         {@link com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity#getRevision() revisions} of the
+   *         {@link com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity#getRevision() revisions} of the
    *         entity with the given {@code id}. In case no such history exists, an {@link List#isEmpty() empty}
    *         {@link List} is returned.
    */
   List<RevisionMetadata> getRevisionHistoryMetadata(ID id, boolean lazy);
 
   /**
-   * @param id the {@link com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity#getId() primary key}.
+   * @param id the {@link com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity#getId() primary key}.
    * @return the {@link RevisionMetadata} of the last historic
-   *         {@link com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity#getRevision() revision} of the
+   *         {@link com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity#getRevision() revision} of the
    *         entity with the given {@code id}. Will be {@code null} if no such history exists.
    */
   RevisionMetadata getLastRevisionHistoryMetadata(ID id);

--- a/starters/starter-spring-data-jpa/src/test/java/com/devonfw/example/general/dataaccess/api/TestApplicationPersistenceEntity.java
+++ b/starters/starter-spring-data-jpa/src/test/java/com/devonfw/example/general/dataaccess/api/TestApplicationPersistenceEntity.java
@@ -8,7 +8,7 @@ import javax.persistence.Transient;
 import javax.persistence.Version;
 
 import com.devonfw.example.general.common.api.TestApplicationEntity;
-import com.devonfw.module.jpa.dataaccess.api.RevisionedPersistenceEntity;
+import com.devonfw.module.basic.common.api.entity.RevisionedPersistenceEntity;
 
 /**
  * Abstract Entity for all Entities with an id and a version field.


### PR DESCRIPTION
I did a refactoring during #18 and moved the `PersistenceEntity` interface from `jpa-basic` to `basic`.
However, I accidentally forgot that for `RevisionedPersistenceEntity` what is fixed with this PR before we finally complete our first release. This allows to reference the interface (e.g. in `api` module) without the full `jpa` dependencies.