### PR TITLE
#77: consistently removed devon4j-configuration also from BOM

### DIFF
--- a/boms/minimal/pom.xml
+++ b/boms/minimal/pom.xml
@@ -52,11 +52,6 @@
       </dependency>
       <dependency>
         <groupId>com.devonfw.java.modules</groupId>
-        <artifactId>devon4j-configuration</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.devonfw.java.modules</groupId>
         <artifactId>devon4j-security</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
isolated final fix for #77 that @AbhayChandel found and fixed in #113