### PR TITLE
#166: fixes for JUnit5 to work properly in all environments

### DIFF
--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -233,7 +233,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.5.2</version>
+        <version>${junit.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -12,7 +12,7 @@
   <version>${devon4j.version}</version>
   <packaging>pom</packaging>
   <name>${project.artifactId}</name>
-  <description>Dependencies (BOM) of the Open Application Standard Platform for Java (devon4j) based on spring boot.</description>
+  <description>Dependencies (BOM) of devon4j based on spring boot.</description>
   <url>https://devon4j.github.io/</url>
   <inceptionYear>2014</inceptionYear>
 

--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -183,7 +183,7 @@
       <dependency>
         <groupId>javax.validation</groupId>
         <artifactId>validation-api</artifactId>
-        <version>1.1.0.Final</version>
+        <version>2.0.1.Final</version>
       </dependency>
       <!-- JAXB -->
       <dependency>
@@ -231,21 +231,22 @@
       <!-- *** optional TEST DEPENDENCIES *** -->
       <!-- JUnit for Test-Case definition and execution -->
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>5.3.2</version>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.5.2</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>org.junit.platform</groupId>
-        <artifactId>junit-platform-runner</artifactId>
-        <version>1.3.2</version>
-        <scope>test</scope>
-       </dependency>
       <!-- Mocking framework for mocks in unit tests -->
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>1.9.5</version>
+        <version>3.1.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>3.1.0</version>
       </dependency>
       <!-- Wiremock for mocking network communication -->
       <dependency>

--- a/boms/minimal/pom.xml
+++ b/boms/minimal/pom.xml
@@ -12,7 +12,7 @@
   <version>${devon4j.version}</version>
   <packaging>pom</packaging>
   <name>${project.artifactId}</name>
-  <description>Dependencies (BOM) of the Open Application Standard Platform for Java (devon4j) without any thirdparty.</description>
+  <description>Dependencies (BOM) of devon4j without any thirdparty.</description>
   <url>https://devon4j.github.io/</url>
   <inceptionYear>2014</inceptionYear>
 

--- a/boms/pom.xml
+++ b/boms/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>devon4j-boms</artifactId>
   <packaging>pom</packaging>
   <name>${project.artifactId}</name>
-  <description>Bill of Materials (BOM) for the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Bill of Materials (BOM) for the devon4j.</description>
 
   <modules> <!-- Order is important here as maven does not track BOM imports as dependencies for reactor build order -->
     <module>minimal</module>

--- a/modules/basic/pom.xml
+++ b/modules/basic/pom.xml
@@ -12,7 +12,7 @@
   <version>${devon4j.version}</version>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
-  <description>Basic code for common usage (such as base classes for transfer objects) of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Basic code for common usage (such as base classes for transfer objects).</description>
 
   <dependencies>
     <!-- JPA only for JavaDoc links -->

--- a/modules/batch/pom.xml
+++ b/modules/batch/pom.xml
@@ -12,7 +12,7 @@
   <version>${devon4j.version}</version>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
-  <description>Batch infrastructure of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Batch infrastructure.</description>
 
   <dependencies>
     <!-- devon4j modules -->

--- a/modules/jpa-basic/pom.xml
+++ b/modules/jpa-basic/pom.xml
@@ -13,7 +13,7 @@
   <version>${devon4j.version}</version>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
-  <description>JPA-based persistence infrastructure of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>JPA-based persistence infrastructure.</description>
 
   <dependencies>
     <dependency>

--- a/modules/jpa-dao/pom.xml
+++ b/modules/jpa-dao/pom.xml
@@ -12,7 +12,7 @@
   <version>${devon4j.version}</version>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
-  <description>JPA-based DAO infrastructure of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>JPA-based DAO infrastructure.</description>
 
   <dependencies>
     <dependency>

--- a/modules/jpa-envers/pom.xml
+++ b/modules/jpa-envers/pom.xml
@@ -12,7 +12,7 @@
   <version>${devon4j.version}</version>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
-  <description>JPA and envers support for Open Application Standard Platform for Java (devon4j).</description>
+  <description>JPA and envers support.</description>
 
   <dependencies>
     <dependency>

--- a/modules/jpa-spring-data/pom.xml
+++ b/modules/jpa-spring-data/pom.xml
@@ -12,7 +12,7 @@
   <version>${devon4j.version}</version>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
-  <description>Spring-data infrastructure for the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Spring-data infrastructure.</description>
   <properties>
     <java.version>1.8</java.version>
   </properties>

--- a/modules/json/pom.xml
+++ b/modules/json/pom.xml
@@ -12,7 +12,7 @@
   <version>${devon4j.version}</version>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
-  <description>JSON Support Module of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>JSON Support Module.</description>
 
   <dependencies>
     <dependency>

--- a/modules/logging/pom.xml
+++ b/modules/logging/pom.xml
@@ -12,7 +12,7 @@
   <version>${devon4j.version}</version>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
-  <description>Logging Module of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Logging Module (not a logger, only extensions for logback).</description>
 
   <dependencies>
     <dependency>

--- a/modules/logging/src/test/java/com/devonfw/module/logging/common/impl/DiagnosticContextFilterTest.java
+++ b/modules/logging/src/test/java/com/devonfw/module/logging/common/impl/DiagnosticContextFilterTest.java
@@ -4,12 +4,9 @@ import static org.mockito.Mockito.when;
 
 import javax.servlet.FilterConfig;
 
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -24,9 +21,6 @@ public class DiagnosticContextFilterTest extends ModuleTest {
   private static final String CORRELATION_ID_HEADER_NAME_PARAM = "correlationIdHttpHeaderName";
 
   private static final String CORRELATION_ID_HEADER_NAME_PARAM_FIELD_NAME = "CORRELATION_ID_HEADER_NAME_PARAM";
-
-  @Rule
-  public MockitoRule rule = MockitoJUnit.rule();
 
   @Mock
   private FilterConfig config;

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>devon4j-modules</artifactId>
   <packaging>pom</packaging>
   <name>${project.artifactId}</name>
-  <description>Reusable modules of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Reusable modules of devon4j.</description>
 
   <modules>
     <module>logging</module>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -46,19 +46,19 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- BOM of spring-boot -->
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <!-- BOM of devon4j -->
       <dependency>
         <groupId>com.devonfw.java.boms</groupId>
         <artifactId>devon4j-bom</artifactId>
         <version>${devon4j.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- BOM of spring-boot -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/modules/rest/pom.xml
+++ b/modules/rest/pom.xml
@@ -12,7 +12,7 @@
   <version>${devon4j.version}</version>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
-  <description>REST-Service Support Module of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>REST-Service Support Module.</description>
 
   <dependencies>
     <dependency>

--- a/modules/security/pom.xml
+++ b/modules/security/pom.xml
@@ -12,7 +12,7 @@
   <version>${devon4j.version}</version>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
-  <description>Security Module of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Security Module for access-control based on spring-security.</description>
 
   <dependencies>
 

--- a/modules/security/src/test/java/com/devonfw/module/security/common/impl/accesscontrol/AccessControlSchemaTest.java
+++ b/modules/security/src/test/java/com/devonfw/module/security/common/impl/accesscontrol/AccessControlSchemaTest.java
@@ -10,7 +10,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ClassPathResource;
 
@@ -19,9 +18,6 @@ import com.devonfw.module.security.common.api.accesscontrol.AccessControlGroup;
 import com.devonfw.module.security.common.api.accesscontrol.AccessControlPermission;
 import com.devonfw.module.security.common.api.accesscontrol.AccessControlProvider;
 import com.devonfw.module.security.common.api.accesscontrol.AccessControlSchema;
-import com.devonfw.module.security.common.impl.accesscontrol.AccessControlProviderImpl;
-import com.devonfw.module.security.common.impl.accesscontrol.AccessControlSchemaProviderImpl;
-import com.devonfw.module.security.common.impl.accesscontrol.AccessControlSchemaXmlMapper;
 import com.devonfw.module.test.common.base.ModuleTest;
 
 /**
@@ -181,14 +177,14 @@ public class AccessControlSchemaTest extends ModuleTest {
     AccessControlSchema accessControlSchema = accessControlSchemaProvider.loadSchema();
     List<AccessControlGroup> groups = accessControlSchema.getGroups();
 
-    Assert.assertNotNull(groups);
-    Assert.assertEquals(3, groups.size());
+    assertThat(groups).isNotNull();
+    assertThat(groups).hasSize(3);
 
     for (AccessControlGroup group : groups) {
       if (group.getId().equals("Admin")) {
-        Assert.assertEquals("role", group.getType());
+        assertThat(group.getType()).isEqualTo("role");
       } else if (group.getId().equals("ReadOnly") || group.getId().equals("ReadWrite")) {
-        Assert.assertEquals("group", group.getType());
+        assertThat(group.getType()).isEqualTo("group");
       }
     }
   }

--- a/modules/service/pom.xml
+++ b/modules/service/pom.xml
@@ -12,7 +12,7 @@
   <version>${devon4j.version}</version>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
-  <description>Service Support Module of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Service Support Module.</description>
 
   <dependencies>
     <dependency>

--- a/modules/test-jpa/pom.xml
+++ b/modules/test-jpa/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>devon4j-test-jpa</artifactId>
   <version>${devon4j.version}</version>
   <name>${project.artifactId}</name>
-  <description>Module with code and configuration for JPA/DB tests of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Module with code and configuration for JPA/DB tests.</description>
 
   <dependencies>
     <dependency>

--- a/modules/test/pom.xml
+++ b/modules/test/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>devon4j-test</artifactId>
   <version>${devon4j.version}</version>
   <name>${project.artifactId}</name>
-  <description>Module with code and configuration for tests of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Module with code and configuration for tests.</description>
 
   <dependencies>
     <dependency>

--- a/modules/test/pom.xml
+++ b/modules/test/pom.xml
@@ -24,6 +24,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/modules/test/pom.xml
+++ b/modules/test/pom.xml
@@ -15,11 +15,7 @@
   <dependencies>
     <dependency>
      <groupId>org.junit.jupiter</groupId>
-     <artifactId>junit-jupiter-engine</artifactId>
-    </dependency>
-    <dependency>
-     <groupId>org.junit.platform</groupId>
-     <artifactId>junit-platform-runner</artifactId>
+     <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/modules/test/src/main/java/com/devonfw/module/test/common/base/ComponentTest.java
+++ b/modules/test/src/main/java/com/devonfw/module/test/common/base/ComponentTest.java
@@ -1,9 +1,8 @@
 package com.devonfw.module.test.common.base;
 
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 
@@ -16,7 +15,7 @@ import com.devonfw.module.test.common.api.category.TagComponentTest;
  *
  * @see TagComponentTest
  */
-@ExtendWith(SpringExtension.class)
+@SpringJUnitConfig
 @TestExecutionListeners({ TransactionalTestExecutionListener.class, DependencyInjectionTestExecutionListener.class })
 @TagComponentTest
 public abstract class ComponentTest extends BaseTest {

--- a/modules/test/src/main/java/com/devonfw/module/test/common/base/SubsystemTest.java
+++ b/modules/test/src/main/java/com/devonfw/module/test/common/base/SubsystemTest.java
@@ -1,9 +1,8 @@
 package com.devonfw.module.test.common.base;
 
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.TestExecutionListeners;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
 
@@ -25,7 +24,7 @@ import com.devonfw.module.test.common.api.category.TagSubsystemTest;
  *
  * @see TagSubsystemTest
  */
-@ExtendWith(SpringExtension.class)
+@SpringJUnitConfig
 @TestExecutionListeners({ TransactionalTestExecutionListener.class, DependencyInjectionTestExecutionListener.class })
 @TagSubsystemTest
 public abstract class SubsystemTest extends BaseTest {

--- a/modules/web/pom.xml
+++ b/modules/web/pom.xml
@@ -13,7 +13,7 @@
   <version>${devon4j.version}</version>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
-  <description>Module for reusable web and servlet related code of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Module for reusable web and servlet related code.</description>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     <maven.archetype.version>3.0.1</maven.archetype.version>
     <jackson.version>2.9.9.20190727</jackson.version> <!-- Overriding Jackson for fixing vulnerabilities -->
     <guava.version>28.1-jre</guava.version>
+    <junit.version>5.5.2</junit.version>
   </properties>
 
   <build>

--- a/starters/pom.xml
+++ b/starters/pom.xml
@@ -24,19 +24,19 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- BOM of spring-boot -->
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <!-- BOM of devon4j -->
       <dependency>
         <groupId>com.devonfw.java.boms</groupId>
         <artifactId>devon4j-bom</artifactId>
         <version>${devon4j.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <!-- BOM of spring-boot -->
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/starters/pom.xml
+++ b/starters/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>devon4j-starters</artifactId>
   <packaging>pom</packaging>
   <name>${project.artifactId}</name>
-  <description>Spring-boot starters of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Spring-boot starters of devon4j.</description>
 
   <modules>
     <module>starter-cxf-client</module>

--- a/templates/pom.xml
+++ b/templates/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>devon4j-templates</artifactId>
   <packaging>pom</packaging>
   <name>${project.artifactId}</name>
-  <description>Templates (maven archetypes) of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Templates (maven archetypes) of devon4j.</description>
 
   <modules>
     <module>server</module>

--- a/templates/server/pom.xml
+++ b/templates/server/pom.xml
@@ -12,7 +12,7 @@
   <version>${devon4j.version}</version>
   <packaging>maven-archetype</packaging>
   <name>${project.artifactId}</name>
-  <description>Application template for the server of the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Application template for a server app based on devon4j.</description>
 
   <build>
     <resources>

--- a/templates/server/src/main/resources/archetype-resources/api/src/test/java/__packageInPathFormat__/ToTest.java
+++ b/templates/server/src/main/resources/archetype-resources/api/src/test/java/__packageInPathFormat__/ToTest.java
@@ -19,7 +19,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.assertj.core.api.SoftAssertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.core.type.filter.AssignableTypeFilter;

--- a/templates/server/src/main/resources/archetype-resources/core/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/core/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>${rootArtifactId}-core</artifactId>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
-  <description>Core of the server for the ${rootArtifactId} application - a simple example using the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Core of the server for the ${rootArtifactId} application - a simple example based on devon4j.</description>
 
   <dependencies>
     <dependency>

--- a/templates/server/src/main/resources/archetype-resources/core/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/core/pom.xml
@@ -206,19 +206,7 @@
     <!-- Tests -->
     <dependency>
       <groupId>com.devonfw.java.modules</groupId>
-      <artifactId>devon4j-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>com.devonfw.java.modules</groupId>
       <artifactId>devon4j-test-jpa</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/templates/server/src/main/resources/archetype-resources/core/src/test/java/__packageInPathFormat__/general/service/impl/rest/SecurityRestServiceImplTest.java
+++ b/templates/server/src/main/resources/archetype-resources/core/src/test/java/__packageInPathFormat__/general/service/impl/rest/SecurityRestServiceImplTest.java
@@ -1,7 +1,6 @@
 package ${package}.general.service.impl.rest;
 
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpEntity;

--- a/templates/server/src/main/resources/archetype-resources/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/pom.xml
@@ -13,6 +13,7 @@
     <spring.boot.version>$[spring.boot.version]</spring.boot.version>
     <devon4j.version>$[devon4j.version]</devon4j.version>
     <java.version>1.8</java.version>
+    <junit.version>$[junit.version]</junit.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jackson.version>$[jackson.version]</jackson.version> <!-- Overriding Jackson for fixing vulnerabilities -->
@@ -34,7 +35,7 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- overriding BOM of jackson -->
+      <!-- overriding jackson version from spring-boot by importing BOM before -->
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
@@ -42,6 +43,14 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- overriding junit version from spring-boot by importing BOM before -->
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>      
       <!-- Library with general utilities -->
       <dependency>
         <groupId>com.google.guava</groupId>

--- a/templates/server/src/main/resources/archetype-resources/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/pom.xml
@@ -70,16 +70,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-runner</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/templates/server/src/main/resources/archetype-resources/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/pom.xml
@@ -7,7 +7,7 @@
   <version>${version}</version>
   <packaging>pom</packaging>
   <name>${project.artifactId}</name>
-  <description>Application based on the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Application based on the devon4j.</description>
 
   <properties>
     <spring.boot.version>$[spring.boot.version]</spring.boot.version>
@@ -23,12 +23,12 @@
   <modules>
     <module>api</module>
     <module>core</module>
-    #if ($earProjectName != '.')
+#if ($earProjectName != '.')
     <module>${earProjectName}</module>
-    #end
-    #if ($batch == 'batch')
+#end
+#if ($batch == 'batch')
     <module>batch</module>
-    #end
+#end
     <module>server</module>
   </modules>
 
@@ -60,8 +60,7 @@
       <dependency>
         <groupId>com.devonfw.java.boms</groupId>
         <artifactId>devon4j-bom</artifactId>
-        <version>${devon4j.version}
-        </version>
+        <version>${devon4j.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/templates/server/src/main/resources/archetype-resources/server/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/server/pom.xml
@@ -10,7 +10,7 @@
   <artifactId>${rootArtifactId}-server</artifactId>
   <packaging>war</packaging>
   <name>${project.artifactId}</name>
-  <description>Server for the ${rootArtifactId} application - a simple example using the Open Application Standard Platform for Java (devon4j).</description>
+  <description>Server for the ${rootArtifactId} application - a simple example based on devon4j.</description>
 
   <dependencies>
     <dependency>

--- a/templates/server/src/main/resources/archetype-resources/server/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/server/pom.xml
@@ -18,13 +18,19 @@
       <artifactId>${rootArtifactId}-core</artifactId>
       <version>${project.version}</version>
     </dependency>
-    #if ($batch == 'batch')
+#if ($batch == 'batch')
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>${rootArtifactId}-batch</artifactId>
       <version>${project.version}</version>
     </dependency>
-    #end
+#end
+    <!-- Tests -->
+    <dependency>
+      <groupId>com.devonfw.java.modules</groupId>
+      <artifactId>devon4j-test-jpa</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
Fix for #166 
Please review. I did not intend to also have the impact on upgrading validation-api but could not find another way as also hibernate-validator was updated by switching the BOM order what was required to overrule spring-boot-dependencies BOM what ships with "broken" junit versions.