### PR TITLE
show SQL from hibernate during development for debugging

### DIFF
--- a/templates/server/src/main/resources/archetype-resources/core/src/main/resources/config/application.properties
+++ b/templates/server/src/main/resources/archetype-resources/core/src/main/resources/config/application.properties
@@ -40,6 +40,10 @@ spring.datasource.password=todo
 spring.datasource.url=jdbc:${dbType}:TODO
 #end
 
+# print SQL to console for debugging (e.g. detect N+1 issues)
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
 # Enable JSON pretty printing
 spring.jackson.serialization.INDENT_OUTPUT=true
 


### PR DESCRIPTION
In every training, I am teaching to enable SQL debugging in hibernate during development as best practice.
Hence, we should have this preconfigured for dev (`config/application.properties`) in our archetype.