### PR TITLE
Rework of devon4j-batch module

### DIFF
--- a/documentation/guide-batch-layer.asciidoc
+++ b/documentation/guide-batch-layer.asciidoc
@@ -45,7 +45,7 @@ It is a typical design decision you have to take when designing your specific ba
 
 == Project structure and packaging
 
-Batches will be implememented in a separate maven module to keep the application core free of batch dependencies. The batch module includes a dependency to the application core-module to allow reuse of the use cases, DAOs etc.
+Batches will be implemented in a separate Maven module to keep the application core free of batch dependencies. The batch module includes a dependency to the application core-module to allow reuse of the use cases, DAOs etc.
 Additionally the batch module has dependencies to the required spring batch jars:
 
 [source,xml]
@@ -197,7 +197,7 @@ E.g. the state will be running, despite the process crashed sometime ago.
 For that cases you have to change the status of the execution in the database.
 
 === CLI-Tool
-Devonfw provides a simple cli-tool to manage the executing status of your jobs.
+Devonfw provides a easy to use cli-tool to manage the executing status of your jobs.
 The tool is implemented in the devonfw module `devon4j-batch-tool`. It will provide a runnable jar, which may be used as follows:
 
 List names of all previous executed jobs::
@@ -211,8 +211,6 @@ Show help::
 
 As you can the each invocation includes the jdbc connection string to your database.
 This means that you have to make sure that the corresponding DB driver is in the classpath (the prepared jar only contains H2).
-
-
 
 == Tipps & tricks
 

--- a/modules/batch/src/main/java/com/devonfw/module/batch/common/base/SpringBootBatchCommandLine.java
+++ b/modules/batch/src/main/java/com/devonfw/module/batch/common/base/SpringBootBatchCommandLine.java
@@ -83,7 +83,12 @@ import org.springframework.util.StringUtils;
  * </pre>
  * </p>
  * <p>
+ *
+ * <b>Deprecated</b> Since spring batch and spring boot are nicely integrated it is possible to start batches without
+ * any custom launcher. This is documented in the current devonfw batch documentation. This launcher is no longer
+ * required and will be removed in one of the next releases.
  */
+@Deprecated
 public class SpringBootBatchCommandLine {
 
   private static final Logger LOG = LoggerFactory.getLogger(SpringBootBatchCommandLine.class);

--- a/modules/batch/src/main/java/com/devonfw/module/batch/common/base/SpringBootBatchCommandLine.java
+++ b/modules/batch/src/main/java/com/devonfw/module/batch/common/base/SpringBootBatchCommandLine.java
@@ -84,9 +84,9 @@ import org.springframework.util.StringUtils;
  * </p>
  * <p>
  *
- * <b>Deprecated</b> Since spring batch and spring boot are nicely integrated it is possible to start batches without
- * any custom launcher. This is documented in the current devonfw batch documentation. This launcher is no longer
- * required and will be removed in one of the next releases.
+ * @deprecated Since spring batch and spring boot are nicely integrated it is possible to start batches without any
+ *             custom launcher. This is documented in the current devonfw batch documentation. This launcher is no
+ *             longer required and will be removed in one of the next releases.
  */
 @Deprecated
 public class SpringBootBatchCommandLine {

--- a/modules/batch/src/main/java/com/devonfw/module/batch/common/impl/JobLauncherWithAdditionalRestartCapabilities.java
+++ b/modules/batch/src/main/java/com/devonfw/module/batch/common/impl/JobLauncherWithAdditionalRestartCapabilities.java
@@ -22,7 +22,7 @@ import org.springframework.batch.core.repository.JobRestartException;
  * the 'run.id' parameter). It is actually just a convenience functionality so that the one starting batches does not
  * have to change the parameters manually.
  *
- * <b>Deprecated</b> Using springs {@link RunIdIncrementer} is sufficient for most use cases.
+ * @deprecated Using springs {@link RunIdIncrementer} is sufficient for most use cases.
  *
  */
 @Deprecated

--- a/modules/batch/src/main/java/com/devonfw/module/batch/common/impl/JobLauncherWithAdditionalRestartCapabilities.java
+++ b/modules/batch/src/main/java/com/devonfw/module/batch/common/impl/JobLauncherWithAdditionalRestartCapabilities.java
@@ -7,6 +7,7 @@ import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersIncrementer;
 import org.springframework.batch.core.JobParametersInvalidException;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
 import org.springframework.batch.core.launch.support.SimpleJobLauncher;
 import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
@@ -21,7 +22,10 @@ import org.springframework.batch.core.repository.JobRestartException;
  * the 'run.id' parameter). It is actually just a convenience functionality so that the one starting batches does not
  * have to change the parameters manually.
  *
+ * <b>Deprecated</b> Using springs {@link RunIdIncrementer} is sufficient for most use cases.
+ *
  */
+@Deprecated
 public class JobLauncherWithAdditionalRestartCapabilities extends SimpleJobLauncher {
 
   private JobRepository jobRepository;
@@ -39,8 +43,8 @@ public class JobLauncherWithAdditionalRestartCapabilities extends SimpleJobLaunc
         // analogous to SimpleJobRepository#createJobExecution
         JobExecution jobExecution = this.jobRepository.getLastJobExecution(job.getName(), jobParameters);
         if (jobExecution.isRunning()) {
-          throw new JobExecutionAlreadyRunningException("A job execution for this job is already running: "
-              + jobExecution.getJobInstance());
+          throw new JobExecutionAlreadyRunningException(
+              "A job execution for this job is already running: " + jobExecution.getJobInstance());
         }
         BatchStatus status = jobExecution.getStatus();
         if (status == BatchStatus.COMPLETED || status == BatchStatus.ABANDONED) {


### PR DESCRIPTION
Rework how jobs are loaded from context (see https://github.com/devonfw/devon4j/issues/190). Made it more similar to SpringsCommandLineJobRunner, which also loads jobs by bean name.
Also the injection of required spring batch-beans as been aligned with
CommandLineJobRunner.