### PR TITLE
Include performance info in separate fields

### DIFF
--- a/modules/logging/pom.xml
+++ b/modules/logging/pom.xml
@@ -19,6 +19,10 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
     </dependency>
+		<dependency>
+		  <groupId>net.logstash.logback</groupId>
+		  <artifactId>logstash-logback-encoder</artifactId>
+		</dependency>    
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>

--- a/modules/logging/src/main/java/com/devonfw/module/logging/common/impl/PerformanceLogFilter.java
+++ b/modules/logging/src/main/java/com/devonfw/module/logging/common/impl/PerformanceLogFilter.java
@@ -91,8 +91,8 @@ public class PerformanceLogFilter implements Filter {
       errorClass = error.getClass().getName();
       errorMessage = error.getMessage();
     }
-    LOG.info("{};{};{};{};{}", v("url", url), v("duration", duration), v("statuscode", statusCode),
-        v("errorClass", errorClass), v("errorMessage", errorMessage));
+    LOG.info("{};{};{};{};{}", v("url", url), v("ms", duration), v("sc", statusCode), v("errCls", errorClass),
+        v("errMsg", errorMessage));
   }
 
   @Override

--- a/modules/logging/src/main/java/com/devonfw/module/logging/common/impl/PerformanceLogFilter.java
+++ b/modules/logging/src/main/java/com/devonfw/module/logging/common/impl/PerformanceLogFilter.java
@@ -91,28 +91,8 @@ public class PerformanceLogFilter implements Filter {
       errorClass = error.getClass().getName();
       errorMessage = error.getMessage();
     }
-    String message = createMessage(url, Long.toString(duration), Integer.toString(statusCode), errorClass,
-        errorMessage);
     LOG.info("{};{};{};{};{}", v("url", url), v("duration", duration), v("statuscode", statusCode),
         v("errorClass", errorClass), v("errorMessage", errorMessage));
-  }
-
-  /**
-   * Returns a {@link String} representing the log message, which contains the given arguments separated by ';'
-   *
-   * @param args - the arguments for the log message
-   * @return a {@link String} representing the log message
-   */
-  private String createMessage(String... args) {
-
-    StringBuilder buffer = new StringBuilder();
-    for (String s : args) {
-      if (buffer.length() > 0) {
-        buffer.append(';');
-      }
-      buffer.append(s);
-    }
-    return buffer.toString();
   }
 
   @Override

--- a/modules/logging/src/main/java/com/devonfw/module/logging/common/impl/PerformanceLogFilter.java
+++ b/modules/logging/src/main/java/com/devonfw/module/logging/common/impl/PerformanceLogFilter.java
@@ -1,5 +1,7 @@
 package com.devonfw.module.logging.common.impl;
 
+import static net.logstash.logback.argument.StructuredArguments.v;
+
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
@@ -46,8 +48,8 @@ public class PerformanceLogFilter implements Filter {
   }
 
   @Override
-  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
-      ServletException {
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
 
     long startTime;
     String path = ((HttpServletRequest) request).getServletPath();
@@ -89,9 +91,10 @@ public class PerformanceLogFilter implements Filter {
       errorClass = error.getClass().getName();
       errorMessage = error.getMessage();
     }
-    String message =
-        createMessage(url, Long.toString(duration), Integer.toString(statusCode), errorClass, errorMessage);
-    LOG.info(message);
+    String message = createMessage(url, Long.toString(duration), Integer.toString(statusCode), errorClass,
+        errorMessage);
+    LOG.info("{};{};{};{};{}", v("url", url), v("duration", duration), v("statuscode", statusCode),
+        v("errorClass", errorClass), v("errorMessage", errorMessage));
   }
 
   /**


### PR DESCRIPTION
I changed our `PerformanceLogFilter` to show how https://github.com/devonfw/devon4j/issues/39 can be solved.

Currently the information is logged twice, once in the original form separated by ; and now additionally in separate fields. I kept the original format for backwards compatibility. If this is not required it is changed quite easily.

The new implementation will created logs like this:

```javascript
{"timestamp":"2020-02-10T14:36:54.299+00:00","message":"http://localhost:8081/services/rest/binary/v1/binaryobject/;21;200;;","logger_name":"com.devonfw.module.logging.common.impl.PerformanceLogFilter","thread_name":"http-nio-8081-exec-7","level":"INFO","url":"http://localhost:8081/services/rest/binary/v1/binaryobject/","duration":21,"statuscode":200,"errorClass":"","errorMessage":"","appname":"rootArtifactId_IS_UNDEFINED"}
```

(prettyfied)
```javascript
{ 
   "timestamp":"2020-02-10T14:36:54.299+00:00",
   "message":"http://localhost:8081/services/rest/binary/v1/binaryobject/;21;200;;",
   "logger_name":"com.devonfw.module.logging.common.impl.PerformanceLogFilter",
   "thread_name":"http-nio-8081-exec-7",
   "level":"INFO",
   "url":"http://localhost:8081/services/rest/binary/v1/binaryobject/",
   "duration":21,
   "statuscode":200,
   "errorClass":"",
   "errorMessage":"",
   "appname":"rootArtifactId_IS_UNDEFINED"
}
```