### PR TITLE
Add unreferenced guides

### DIFF
--- a/documentation/devon4j.asciidoc
+++ b/documentation/devon4j.asciidoc
@@ -44,6 +44,8 @@ include::guide-client-layer.asciidoc[leveloffset=2]
 
 include::guide-service-layer.asciidoc[leveloffset=2]
 
+include::guide-service-versioning.asciidoc[leveloffset=2]
+
 <<<<
 
 include::guide-logic-layer.asciidoc[leveloffset=2]
@@ -186,6 +188,50 @@ include::guide-jdk.asciidoc[leveloffset=2]
 <<<<
 
 include::guide-microservice.asciidoc[leveloffset=2]
+
+<<<<
+
+include::guide-accessibility.asciidoc[leveloffset=2]
+
+<<<<
+
+include::guide-apm.asciidoc[leveloffset=2]
+
+<<<<
+
+include::guide-caching.asciidoc[leveloffset=2]
+
+<<<<
+
+include::guide-component.asciidoc[leveloffset=2]
+
+<<<<
+
+include::guide-feature-toggle.asciidoc[leveloffset=2]
+
+<<<<
+
+include::guide-accessibility.asciidoc[leveloffset=2]
+
+<<<<
+
+include::guide-jee.asciidoc[leveloffset=2]
+
+<<<<
+
+include::guide-kafka.asciidoc[leveloffset=2]
+
+<<<<
+
+include::guide-jms.asciidoc[leveloffset=2]
+
+<<<<
+
+include::guide-monitoring.asciidoc[leveloffset=2]
+
+<<<<
+
+include::guide-text-search.asciidoc[leveloffset=2]
 
 == Tutorials
 


### PR DESCRIPTION
When trying to add the new kafka guide to the devon4j.asciidoc I noticed that several other guides are missing. I added all missing guides in this PR.