### PR TITLE
Fix errors in devon4j-security tests if locale is not set to English

### DIFF
--- a/modules/security/src/test/java/com/devonfw/module/security/common/impl/accesscontrol/AccessControlSchemaTest.java
+++ b/modules/security/src/test/java/com/devonfw/module/security/common/impl/accesscontrol/AccessControlSchemaTest.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,8 @@ public class AccessControlSchemaTest extends ModuleTest {
   public AccessControlSchemaTest() {
 
     super();
+    // Assure error message, we are testing for are in English.
+    Locale.setDefault(Locale.ENGLISH);
   }
 
   /**

--- a/modules/security/src/test/java/com/devonfw/module/security/common/impl/accesscontrol/AccessControlSchemaTest.java
+++ b/modules/security/src/test/java/com/devonfw/module/security/common/impl/accesscontrol/AccessControlSchemaTest.java
@@ -48,7 +48,7 @@ public class AccessControlSchemaTest extends ModuleTest {
   public AccessControlSchemaTest() {
 
     super();
-    // Assure error message, we are testing for are in English.
+    // Assure error messages, we are testing for are in English.
     Locale.setDefault(Locale.ENGLISH);
   }
 


### PR DESCRIPTION
AccessControlSchemaTest.testProviderIllegal tests for specific text in error messages. These change with different locale settings. I set the locale in the java code. It might be possible to do this alternatively for all devon4j tests by reconfiguring surefire. I chose the less invasive approach...