### PR TITLE
Upgrad libs

### DIFF
--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -322,15 +322,6 @@
         <scope>test</scope>
       </dependency>
 
-      <!-- Overwrite Spring Cloud Sleuth Brave version do avoid unimplemented 
-        close(Duration) method in brave.kafka.clients.TracingProducer<K, V> -->
-      <dependency>
-        <groupId>io.zipkin.brave</groupId>
-        <artifactId>brave-bom</artifactId>
-        <version>5.6.4</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
     <github.repository>devon4j</github.repository>
     <github.default.branch>develop</github.default.branch>
     <devon4j.version>${revision}${changelist}</devon4j.version>
-    <spring.boot.version>2.2.6.RELEASE</spring.boot.version>
+    <spring.boot.version>2.2.7.RELEASE</spring.boot.version>
     <!-- Spring boot and spring cloud version has to match -->
-    <spring.cloud.dependencies.version>Greenwich.RELEASE</spring.cloud.dependencies.version>
+    <spring.cloud.dependencies.version>Greenwich.SR6</spring.cloud.dependencies.version>
     <jackson.version>2.10.3</jackson.version> <!-- Overriding Jackson for fixing vulnerabilities -->
     <guava.version>28.1-jre</guava.version>
     <junit.version>5.6.1</junit.version>


### PR DESCRIPTION
spring boot 2.3.6 -> 2.3.7 (introduces e.g. kafka 2.3.7 ->2.3.8)
spring cloud greenwich RELEASE -> SR6 (avoids manual brave upgrade)

this should also address https://github.com/devonfw/devon4j/issues/272