### PR TITLE
Fix for bootified jar

### DIFF
--- a/templates/server/src/main/resources/archetype-resources/core/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/core/pom.xml
@@ -1,4 +1,4 @@
-﻿﻿<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
@@ -252,6 +252,17 @@
           </excludes>
         </configuration>
       </plugin>
+      <plugin>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-maven-plugin</artifactId>
+			<executions>
+				<execution>
+					<goals>
+						<goal>repackage</goal>
+					</goals>
+				</execution>
+			</executions>
+	  </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Fix for issue https://github.com/devonfw/devon4j/issues/295 

After creating project with updated archetype we should be able to run jar with command java -jar jarname.