### PR TITLE
WIP: update spring-boot to 2.4.0, other small updates

### DIFF
--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -18,11 +18,6 @@
   <inceptionYear>2014</inceptionYear>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <cxf.version>3.3.6</cxf.version>
-    <mmm.util.version>8.7.0</mmm.util.version>
-    <slf4j.version>1.7.28</slf4j.version>
     <flatten.mode>bom</flatten.mode>
   </properties>
 
@@ -73,7 +68,7 @@
         <artifactId>javax.inject</artifactId>
         <version>1</version>
       </dependency>
-      <!-- JSR 250 for common annotations (component-bean lifecycle, security, 
+      <!-- JSR 250 for common annotations (component-bean lifecycle, security,
         etc.) -->
       <dependency>
         <groupId>javax.annotation</groupId>

--- a/modules/kafka/src/main/java/com/devonfw/module/kafka/common/messaging/logging/impl/MessageListenerLoggingAspect.java
+++ b/modules/kafka/src/main/java/com/devonfw/module/kafka/common/messaging/logging/impl/MessageListenerLoggingAspect.java
@@ -1,6 +1,6 @@
 package com.devonfw.module.kafka.common.messaging.logging.impl;
 
-import static brave.internal.HexCodec.toLowerHex;
+import static brave.internal.codec.HexCodec.toLowerHex;
 
 import java.lang.reflect.Method;
 import java.time.Instant;

--- a/modules/kafka/src/main/java/com/devonfw/module/kafka/common/messaging/trace/impl/MessageSpanExtractor.java
+++ b/modules/kafka/src/main/java/com/devonfw/module/kafka/common/messaging/trace/impl/MessageSpanExtractor.java
@@ -1,6 +1,6 @@
 package com.devonfw.module.kafka.common.messaging.trace.impl;
 
-import static brave.internal.HexCodec.lowerHexToUnsignedLong;
+import static brave.internal.codec.HexCodec.lowerHexToUnsignedLong;
 import static com.devonfw.module.kafka.common.messaging.util.MessageUtil.getHeaderValue;
 
 import java.util.Optional;

--- a/modules/kafka/src/main/java/com/devonfw/module/kafka/common/messaging/trace/impl/MessageSpanInjector.java
+++ b/modules/kafka/src/main/java/com/devonfw/module/kafka/common/messaging/trace/impl/MessageSpanInjector.java
@@ -1,6 +1,6 @@
 package com.devonfw.module.kafka.common.messaging.trace.impl;
 
-import static brave.internal.HexCodec.toLowerHex;
+import static brave.internal.codec.HexCodec.toLowerHex;
 import static com.devonfw.module.kafka.common.messaging.util.MessageUtil.addHeaderValue;
 
 import java.util.Optional;

--- a/modules/kafka/src/test/java/com/devonfw/example/module/MessageRetryOperationsTest.java
+++ b/modules/kafka/src/test/java/com/devonfw/example/module/MessageRetryOperationsTest.java
@@ -1,9 +1,9 @@
 package com.devonfw.example.module;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
-import org.apache.commons.codec.Charsets;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Headers;
@@ -40,10 +40,11 @@ public class MessageRetryOperationsTest extends AbstractKafkaBaseTest {
   @Override
   protected void doSetUp() {
 
-    this.consumerRecord = new ConsumerRecord<>(AbstractKafkaBaseTest.RETRY_TEST_TOPIC, 0, 0, AbstractKafkaBaseTest.RETRY_TEST_TOPIC, "message");
+    this.consumerRecord = new ConsumerRecord<>(AbstractKafkaBaseTest.RETRY_TEST_TOPIC, 0, 0,
+        AbstractKafkaBaseTest.RETRY_TEST_TOPIC, "message");
     Headers headers = this.consumerRecord.headers();
-    headers.add(MessageRetryContext.RETRY_COUNT, "0".getBytes(Charsets.UTF_8));
-    headers.add(MessageRetryContext.RETRY_STATE, "Pending".getBytes(Charsets.UTF_8));
+    headers.add(MessageRetryContext.RETRY_COUNT, "0".getBytes(StandardCharsets.UTF_8));
+    headers.add(MessageRetryContext.RETRY_STATE, "Pending".getBytes(StandardCharsets.UTF_8));
     headers.add(MessageRetryContext.RETRY_NEXT, Instant.now().plus(1, ChronoUnit.MINUTES).toString().getBytes());
     headers.add(MessageRetryContext.RETRY_UNTIL, Instant.now().toString().getBytes());
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <github.repository>devon4j</github.repository>
     <github.default.branch>develop</github.default.branch>
     <devon4j.version>${revision}${changelist}</devon4j.version>
-    <spring.boot.version>2.3.3.RELEASE</spring.boot.version>
+    <spring.boot.version>2.4.0</spring.boot.version>
     <!-- Spring boot and spring cloud version has to match -->
     <spring.cloud.dependencies.version>Greenwich.SR6</spring.cloud.dependencies.version>
     <jackson.version>2.11.2</jackson.version> <!-- Overriding Jackson for fixing vulnerabilities -->

--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,13 @@
     <devon4j.version>${revision}${changelist}</devon4j.version>
     <spring.boot.version>2.4.0</spring.boot.version>
     <!-- Spring boot and spring cloud version has to match -->
-    <spring.cloud.dependencies.version>Greenwich.SR6</spring.cloud.dependencies.version>
+    <spring.cloud.dependencies.version>Hoxton.SR9</spring.cloud.dependencies.version>
     <jackson.version>2.11.2</jackson.version> <!-- Overriding Jackson for fixing vulnerabilities -->
-    <guava.version>28.1-jre</guava.version>
-    <junit.version>5.6.1</junit.version>
-    
+    <guava.version>30.0-jre</guava.version>
+    <junit.version>5.7.0</junit.version>
+    <cxf.version>3.4.1</cxf.version>
+    <mmm.util.version>8.7.0</mmm.util.version>
+    <slf4j.version>1.7.30</slf4j.version>
   </properties>
 
   <build>


### PR DESCRIPTION
This PR is WIP. Do not yet merge.
* update spring-boot to 2.4.0 (from 2.3.3.RELEASE)
* update spring-cloud to Hoxton.SR9 (from Greenwich.SR6)
* update guava to 30.0-jre (from 28.0-jre)
* update junit to 5.7.0 (from 5.6.1)
* update slf4j to 1.7.30 (from 1.7.28)

However, the kafka stuff breaks into pieces:
* for unclear reasons we used `brave.internal.HexCodec.toLowerHex` to convert a number to its hex value. Why do we need an external lib for this (instead of using `java.lang.Integer`) and especially from an internal package. However, just the package changed so I could fix this one easily.
* `org.apache.kafka.clients.producer.ProducerRecord` has changed its API in an incompatible way. I have fixed this and hope I did well.

The major remaining problem is that spring-cloud is based on a long deprecated class `ConfigurationBeanFactoryMetadata` from spring boot that has been removed in `2.4.0`. However this is still included in the latest spring-cloud release.
JUnit test therefore fails with:
```
Caused by: java.lang.ClassNotFoundException: org.springframework.boot.context.properties.ConfigurationBeanFactoryMetadata
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	... 110 common frames omitted
```

Real cause is hard to trace but I found it here:
https://github.com/spring-cloud/spring-cloud-config/issues/1543