### PR TITLE
Bugfixing initialized flag in BaseTest

### DIFF
--- a/modules/test/src/main/java/com/devonfw/module/test/common/base/BaseTest.java
+++ b/modules/test/src/main/java/com/devonfw/module/test/common/base/BaseTest.java
@@ -43,7 +43,7 @@ public abstract class BaseTest extends Assertions {
    * Indicates if the test class is to be set up for the first time. {@code true} indicates that the class has already
    * been set up (e.g., database setup) for the execution of an preceding test method.
    */
-  protected static boolean INITIALIZED = false;
+  protected boolean initialized = false;
 
   /**
    * Suggests to use {@link #doSetUp()} method before each tests.
@@ -53,8 +53,8 @@ public abstract class BaseTest extends Assertions {
 
     // Simply sets INITIALIZED to true when setUp is called for the first time.
     doSetUp();
-    if (!INITIALIZED) {
-      INITIALIZED = true;
+    if (!initialized) {
+      initialized = true;
     }
   }
 
@@ -73,7 +73,7 @@ public abstract class BaseTest extends Assertions {
    */
   protected boolean isInitialSetup() {
 
-    return INITIALIZED;
+    return !initialized;
   }
 
   /**


### PR DESCRIPTION
As the initialized flag was declared static, it was used as an indicator for first initialization of any test (using BaseTest), not only for the test class. To make it work as it was intended, 'static' needs to be removed. I renamed the property from upper to lower case to reflect that it's not static.

Also, the method isInitialSetup() inverts the meaning of the flag, but simply uses it directly. The class is in it's initial state when it wasn't initialized before. To fix this, I introduced inverting the flag in the method.

I hope I didn't break anything with editing this directly in GitHub without IDE support. This especially means I wasn't able to test the change. As the flag is declared protected, it might be used directly in other classes.