### PR TITLE
#85: use revision variable directly

### DIFF
--- a/templates/server/src/main/resources/archetype-resources/.mvn/maven.config
+++ b/templates/server/src/main/resources/archetype-resources/.mvn/maven.config
@@ -1,1 +1,1 @@
--Drevision=$version
+-Drevision=${version}

--- a/templates/server/src/main/resources/archetype-resources/__batch__/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/__batch__/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>${groupId}</groupId>
     <artifactId>${rootArtifactId}</artifactId>
-    <version>${app.version}</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>${rootArtifactId}-batch</artifactId>
   <packaging>jar</packaging>

--- a/templates/server/src/main/resources/archetype-resources/__earProjectName__/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/__earProjectName__/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
-    <version>${app.version}</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>${earProjectName}</artifactId>
   <name>${project.artifactId}</name>

--- a/templates/server/src/main/resources/archetype-resources/api/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>${groupId}</groupId>
     <artifactId>${rootArtifactId}</artifactId>
-   <version>${app.version}</version>
+   <version>${revision}</version>
   </parent>
   <artifactId>${rootArtifactId}-api</artifactId>
   <packaging>jar</packaging>

--- a/templates/server/src/main/resources/archetype-resources/core/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>${groupId}</groupId>
     <artifactId>${rootArtifactId}</artifactId>
-    <version>${app.version}</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>${rootArtifactId}-core</artifactId>
   <packaging>jar</packaging>

--- a/templates/server/src/main/resources/archetype-resources/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>${artifactId}</artifactId>
   <groupId>${groupId}</groupId>
-  <version>${app.version}</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
   <name>${project.artifactId}</name>
   <description>Application based on the devon4j.</description>
@@ -19,18 +19,17 @@
     <jackson.version>$[jackson.version]</jackson.version> <!-- Overriding Jackson for fixing vulnerabilities -->
     <guava.version>$[guava.version]</guava.version>
     <devonfw.test.excluded.groups>system</devonfw.test.excluded.groups>
-    <app.version>${revision}</app.version>
   </properties>
 
   <modules>
     <module>api</module>
     <module>core</module>
-    #if ($earProjectName != '.')
+#if ($earProjectName != '.')
     <module>${earProjectName}</module>
-    #end
-    #if ($batch == 'batch')
+#end
+#if ($batch == 'batch')
     <module>batch</module>
-    #end
+#end
     <module>server</module>
   </modules>
 

--- a/templates/server/src/main/resources/archetype-resources/server/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>${groupId}</groupId>
     <artifactId>${rootArtifactId}</artifactId>
-     <version>${app.version}</version>
+     <version>${revision}</version>
   </parent>
   <artifactId>${rootArtifactId}-server</artifactId>
   <packaging>war</packaging>


### PR DESCRIPTION
Completed #85 with nice-to-have-improvements

* use revision variable directly (remove `app.version` variable)
* also removed macro whitespaces to avoid broken indentation in resulting pom