### PR TITLE
#393: derive Application test classes from DbTest

### DIFF
--- a/templates/server/src/main/resources/archetype-resources/core/src/test/java/__packageInPathFormat__/general/common/base/test/ApplicationComponentTest.java
+++ b/templates/server/src/main/resources/archetype-resources/core/src/test/java/__packageInPathFormat__/general/common/base/test/ApplicationComponentTest.java
@@ -1,6 +1,6 @@
 package ${package}.general.common.base.test;
 
-import com.devonfw.module.test.common.base.ComponentTest;
+import com.devonfw.module.test.common.base.ComponentDbTest;
 
 import ${package}.SpringBootApp;
 
@@ -11,7 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
  * Abstract base class for {@link ComponentTest}s of this application.
  */
 @SpringBootTest(classes = { SpringBootApp.class }, webEnvironment = WebEnvironment.MOCK)
-public abstract class ApplicationComponentTest extends ComponentTest {
+public abstract class ApplicationComponentTest extends ComponentDbTest {
 
   @Override
   protected void doTearDown() {

--- a/templates/server/src/main/resources/archetype-resources/core/src/test/java/__packageInPathFormat__/general/common/base/test/ApplicationSubsystemTest.java
+++ b/templates/server/src/main/resources/archetype-resources/core/src/test/java/__packageInPathFormat__/general/common/base/test/ApplicationSubsystemTest.java
@@ -1,6 +1,6 @@
 package ${package}.general.common.base.test;
 
-import com.devonfw.module.test.common.base.SubsystemTest;
+import com.devonfw.module.test.common.base.SubsystemDbTest;
 
 import ${package}.SpringBootApp;
 
@@ -11,6 +11,6 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
  * Abstract base class for {@link SubsystemTest}s of this application.
  */
 @SpringBootTest(classes = { SpringBootApp.class }, webEnvironment = WebEnvironment.RANDOM_PORT)
-public abstract class ApplicationSubsystemTest extends SubsystemTest {
+public abstract class ApplicationSubsystemTest extends SubsystemDbTest {
 
 }


### PR DESCRIPTION
implementation part of #393 that makes the `Application*Test` classes from our archetype indirectly derive from `DbTest` to avoid issues with `JpaHelper`.