### PR TITLE
#216: servicedoc 1.0.0, generate by default

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -11,6 +11,8 @@ Bugfix release of with the following stories:
 * https://github.com/devonfw/devon4j/issues/336[#336]: archetype contains batch artefacts even when no batch was generated
 * https://github.com/devonfw/devon4j/issues/385[#385]: Access-control should honor roles by default
 * https://github.com/devonfw/devon4j/issues/397[#397]: security-jwt should support the claim "groups" from the microprofile jwt
+* https://github.com/devonfw/devon4j/issues/393[#393]: devon4j JpaInitializer documentation not matching releases
+* https://github.com/devonfw/devon4j/issues/216[#216]: ability to generate OpenApi files automatically from JAX-RS services
 
 Documentation is available at https://repo.maven.apache.org/maven2/com/devonfw/java/doc/devon4j-doc/2021.04.003/devon4j-doc-2021.04.003.pdf[devon4j guide 2021.04.003].
 The full list of changes for this release can be found in https://github.com/devonfw/devon4j/milestone/19?closed=1[milestone devon4j 2020.04.003].

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.devonfw</groupId>
     <artifactId>maven-parent</artifactId>
-    <version>6</version>
+    <version>8</version>
   </parent>
   <groupId>com.devonfw.java.dev</groupId>
   <artifactId>devon4j</artifactId>

--- a/templates/server/src/main/resources/archetype-resources/pom.xml
+++ b/templates/server/src/main/resources/archetype-resources/pom.xml
@@ -120,7 +120,7 @@
           </execution>
         </executions>
       </plugin>
-      
+
       <!-- generate and use flattened pom instead of pom.xml -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -141,6 +141,19 @@
             <phase>clean</phase>
             <goals>
               <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>servicedocgen-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>servicedocgen-generate</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>generate</goal>
             </goals>
           </execution>
         </executions>
@@ -319,6 +332,20 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>servicedocgen-maven-plugin</artifactId>
           <version>$[mojo.servicedocgen.plugin.version]</version>
+          <configuration>
+            <descriptor>
+              <info>
+                <title>${servicedoc.info.title}</title>
+                <description>${servicedoc.info.description}</description>
+              </info>
+              <host>${servicedoc.host}</host>
+              <port>${servicedoc.port}</port>
+              <basePath>${servicedoc.basePath}</basePath>
+              <schemes>
+                <scheme>http</scheme>
+              </schemes>
+            </descriptor>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.sonarsource.scanner.maven</groupId>
@@ -437,7 +464,7 @@
     </profile>
   </profiles>
 
-  #if ($dbType == 'oracle')
+#if ($dbType == 'oracle')
   <repositories>
     <repository>
       <id>maven.oracle.com</id>
@@ -463,7 +490,7 @@
     </pluginRepository>
   </pluginRepositories>
 
-  #end
+#end
   <reporting>
     <plugins>
       <plugin>
@@ -512,20 +539,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>servicedocgen-maven-plugin</artifactId>
-        <configuration>
-          <descriptor>
-            <info>
-              <title>${servicedoc.info.title}</title>
-              <description>${servicedoc.info.description}</description>
-            </info>
-            <host>${servicedoc.host}</host>
-            <port>${servicedoc.port}</port>
-            <basePath>${servicedoc.basePath}</basePath>
-            <schemes>
-              <scheme>http</scheme>
-            </schemes>
-          </descriptor>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Implements #216:
* now servicedocgen 1.0.0 is used
* service documentation is generated by default in regular build
* SwaggerUI is also included (requires content to be served via HTTP server)