### PR TITLE
Correction of Spring vs Quarkus guides

### DIFF
--- a/documentation/Spring-native-vs-Quarkus.asciidoc
+++ b/documentation/Spring-native-vs-Quarkus.asciidoc
@@ -1,4 +1,7 @@
-== Spring Native vs Quarkus
+:toc: macro
+toc::[]
+
+= Spring Native vs Quarkus
 
 Nowadays, it is very common to write an application and deploy it to a cloud. 
 Serverless computing and Function-as-a-Service (FaaS) have become
@@ -7,7 +10,7 @@ While many challenges arise when deploying a Java application into the latest cl
 for the Java application, as more of these keeps the host's costs high in public clouds and Kubernetes clusters. With the introduction of frameworks like micronaut and microprofile, Java processes are getting faster and more lightweight. In a similar context, Spring has introduced
 https://docs.spring.io/spring-native/docs/current/reference/htmlsingle/#overview[Spring Native] which aims to solve the big memory footprint of Spring and its slow startup time to potentially rival the new framework called https://quarkus.io[Quarkus], by Red Hat. This document briefly discusses both of these two frameworks and their potential suitability with devonfw.
 
-=== Quarkus
+== Quarkus
 
 Quarkus is a full-stack, Kubernetes-native Java framework made for JVMs. With its container-first-philosophy and its native compilation with GraalVM, Quarkus optimizes Java for containers with low memory usage and fast startup times.
 
@@ -28,7 +31,8 @@ executable, resulting in an even faster startup-time.
 
 This gives Quarkus the potential for a great platform for serverless cloud and Kubernetes environments. For more information about Quarkus and its support for devonfw please refer to the link:quarkus.asciidoc[Quarkus introduction guide].
 
-=== Spring Native
+== Spring Native
+
 ====
 *The current version of Spring Native 0.10.5 is designed to be used with Spring Boot 2.5.6*
 ====
@@ -55,7 +59,7 @@ Spring Native is composed of the following modules:
 
 * *samples:* contains various samples that demonstrate features usage and are used as integration tests.
 
-=== Native compilation with GraalVM    
+== Native compilation with GraalVM    
 
 Quarkus and Spring Native both use GraalVM for native compilation. Using a native image provides some key advantages, such as instant startup, instant peak performance, and reduced memory consumption. However, there are also some drawbacks: Creating a native image is a heavy process that is slower than a regular application. A native image also has fewer runtime optimizations after its warmup. Furthermore, it is less mature than the JVM and comes with some different behaviors.
 
@@ -71,7 +75,7 @@ performed at build time.
 
 There are https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/Limitations.md[limitations] around some aspects of Java applications that are not fully supported
 
-=== Build time and start time for apps
+== Build time and start time for apps
 
 [cols=",,",options="header",]
 |===
@@ -80,7 +84,7 @@ There are https://github.com/oracle/graal/blob/master/docs/reference-manual/nati
 |Quarkus Native executable |52.818s |0.802s
 |===
 
-=== Memory footprints
+== Memory footprints
 
 [cols=",",options="header",]
 |===
@@ -89,7 +93,7 @@ There are https://github.com/oracle/graal/blob/master/docs/reference-manual/nati
 |Quarkus Native executable |75 MB
 |===
 
-=== Considering devonfw best practices
+== Considering devonfw best practices
 
 As of now, devonfw actively supports Spring but not Spring Native. 
 Although Quarkus has been released to a stable release in early 2021, it has been already used in multiple big projects successfully showing its potential to implement cloud native services with low resource consumption matching the needs of scalability and resilience in cloud native environments.
@@ -101,7 +105,7 @@ for Spring developers] who want to adopt or try Quarkus for their
 (next) projects as it really has some gamechanging advantages over
 Spring.
 
-=== General recommendations and conclusion
+== General recommendations and conclusion
 
 Quarkus and Spring Native both have their own use cases. Under the consideration of the limitations of GraalVM to be used for native images built by Quarkus and Spring Native, there is a strong recommendation towards Quarkus from devonfw. 
 One essential differentiation has to be made on the decision for native or against native applications - the foreseen performance optimization of the JIT compiler of the JVM, which is not available anymore in a native image deployment. 

--- a/documentation/decision-between-Spring-and-Quarkus.asciidoc
+++ b/documentation/decision-between-Spring-and-Quarkus.asciidoc
@@ -1,8 +1,11 @@
-== Decision between Spring and Quarkus
+:toc: macro
+toc::[]
 
-=== Spring
+= Decision between Spring and Quarkus
 
-==== Pros
+== Spring
+
+=== Pros
 * *highly flexible:*
 Spring is famous for its great flexibility. You can customize and integrate nearly everything.
 
@@ -14,7 +17,7 @@ As a result you can easily find a lot of developers, experts, books, articles, e
 * *non-invasive and not biased:*
 Spring became famous for its non-invasive coding based on patterns instead of hard dependencies. It gives you a lot of freedom and avoids tight coupling of your (business) code.
 
-==== Cons
+=== Cons
 
 * *history and legacy:*
 Due to its long established history, spring carries a lot of legacy. 
@@ -25,7 +28,7 @@ Spring Developers needs some guidance (e.g. via devon4j) as they may enter pitfa
 While for the last decades spring was leading innovation in Java app development, it seems that with the latest trends and shift such as cloud-native, they have been overtaken by frameworks like Quarkus. 
 However, spring is trying to catch up with spring-native.
 
-=== Quarkus
+== Quarkus
 
 === Quarkus main information:
 Quarkus is a full-stack, Kubernetes-native Java framework made for JVMs.
@@ -51,7 +54,7 @@ Another big advantage of Quarkus is that it started on a green field and therefo
 Nonetheless, there is a experimental support also for some spring libraries already available in Quarkus, which make switching from spring to Quarkus much more easier if needed.
 We also provide a link:quarkus/getting-started-for-spring-developers.asciidoc[guide for Spring developers] who want to adopt or try Quarkus for their (next) projects as it really has some gamechanging advantages over Spring.
 
-==== Pros:
+=== Pros:
 
 * *fast turn-around cycles for developers:* Save changes in your Java code and immediately test the results without restarting or waiting
 
@@ -62,7 +65,7 @@ You can find a performance comparison between Spring and Quarkus here.
 
 * *clean and lean:* As Quarkus was born as cloud-native framework it is very light-weight and does not carry much history and legacy.
 
-==== Cons:
+=== Cons:
 
 * *less flexible:*
 Quarkus is less flexible compared to spring or in other words it is more biased and coupled to specific implementations. However, the implementations just work and you have less things to choose and worry about.
@@ -72,6 +75,6 @@ Therefore, check your requirements and technology stack early on when making you
 * *less established:*
 Since Quarkus was born in 2019 it is modern but also less established. It will be easier to get developers for spring but we already consider Quarkus mature and established enought for building production ready apps.
 
-=== General Recommendation
+== General Recommendation
 One essential differentiation has to be made on the decision for native or against native applications - the foreseen performance optimization of the JIT compiler of the JVM, which is not available anymore in a native image deployment.
 Depending on the overall landscape, it is recommended to stay with the knowledge of the available teams, e.g. continue making use of devon4j based on spring or even if already in that state, make use of Quarkus on JVM.

--- a/documentation/devon4j.asciidoc
+++ b/documentation/devon4j.asciidoc
@@ -26,6 +26,8 @@ However, the general coding patterns are based on common Java standards mainly f
 Therefore, the xref:general[general] section contains all the documentation that is universal to Java and does not differ between the two frameworks.
 Only the sections link:spring.asciidoc[spring] and link:quarkus.asciidoc[quarkus] contain documentation that is specific to the respective approach.
 
+If you're trying to decide which of the two frameworks to use, have a look at link:decision-between-Spring-and-Quarkus.asciidoc[this guide].
+
 You can also read the latest version of this documentation online at the following sources:
 
 * https://github.com/devonfw/devon4j/wiki[devon4j on github wiki]
@@ -285,6 +287,8 @@ include::quarkus/getting-started-quarkus.asciidoc[leveloffset=+2]
 
 include::guide-migration-spring-quarkus.asciidoc[leveloffset=+2]
 
+include::Spring-native-vs-Quarkus.asciidoc[leveloffset=+2]
+
 include::guide-structure-modern.asciidoc[leveloffset=+2]
 
 include::guide-domain-layer.asciidoc[leveloffset=+2]
@@ -295,7 +299,6 @@ include::guide-domain-layer.asciidoc[leveloffset=+2]
 
 include::quarkus/getting-started-for-spring-developers.asciidoc[leveloffset=+3]
 include::quarkus/guide-quarkus-configuration.asciidoc[leveloffset=+3]
-include::Spring-native-vs-Quarkus.asciidoc[leveloffset=+3]
 include::quarkus/quarkus-template.asciidoc[leveloffset=+3]
 include::quarkus/guide-native-image.asciidoc[leveloffset=+3]
 include::quarkus/guide-beanmapping-quarkus.asciidoc[leveloffset=+3]


### PR DESCRIPTION
* Moved Spring Native vs Quarkus guide to a different place in the outline (was not shown in the outline at all before)
* Linked decision guide between Spring and Quarkus in the general Java section