### PR TITLE
#585: get rid of spring-cloud, disable kafka module, updates 

### DIFF
--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -32,14 +32,6 @@
         <scope>import</scope>
       </dependency>
       <!-- *** EXTERNAL DEPENDENCIES *** -->
-      <!--Spring cloud dependencies BOM -->
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-dependencies</artifactId>
-        <version>${spring.cloud.dependencies.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <!-- Library with general utilities as well as I18N and exception support -->
       <dependency>
         <groupId>net.sf.m-m-m</groupId>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -44,7 +44,6 @@
     <module>batch-tool</module>
     <module>web</module>
     <module>basic</module>
-    <module>kafka</module>
   </modules>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,8 @@
     <revision>dev-SNAPSHOT</revision>
     <github.repository>devon4j</github.repository>
     <devon4j.version>${revision}</devon4j.version>
-    <spring.boot.version>2.7.6</spring.boot.version>
-    <!-- Spring boot and spring cloud version has to match -->
-    <spring.cloud.dependencies.version>2021.0.1</spring.cloud.dependencies.version>
-    <jackson.version>2.13.2.20220328</jackson.version> <!-- Overriding Jackson for fixing vulnerabilities -->
+    <spring.boot.version>2.7.7</spring.boot.version>
+    <jackson.version>2.14.1</jackson.version> <!-- Overriding Jackson for fixing vulnerabilities -->
     <guava.version>31.1-jre</guava.version>
     <junit.version>5.7.1</junit.version>
     <cxf.version>3.5.5</cxf.version>


### PR DESCRIPTION
addresses #585 with:
* kick out kafka module (no more releases of devon4j-kafka, please use spring kafka module instead)
* remove spring-cloud from our dependency-management and BOM
* update spring-boot to 2.7.7
* update jackson to 2.14.1